### PR TITLE
[PR] Refactor crawler to better manage memory

### DIFF
--- a/crawl.js
+++ b/crawl.js
@@ -86,11 +86,12 @@ function storeURLs( response ) {
 
 		var elastic = elasticClient();
 		elastic.bulk( { body: bulk_body } )
-			.then( function( response ) {
+			.then( function() {
 				wsu_web_crawler.stored_urls = wsu_web_crawler.stored_urls + urls.length;
 				resolve();
 			} )
 			.catch( function( error ) {
+
 				// @todo should some URLs be added back to store_urls?
 				reject( "Bulk URL storage not successful: " + error.message );
 			} );
@@ -165,12 +166,12 @@ function updateURLData( url, data ) {
 				util.log( "Updated: " + url );
 			} )
 			.catch( function( error ) {
-				wsu_web_crawler.scan_urls.push(url);
-				util.log("Error (updateURLData 2): " + url + " " + error.message );
+				wsu_web_crawler.scan_urls.push( url );
+				util.log( "Error (updateURLData 2): " + url + " " + error.message );
 			} );
 		}
 	} ).catch( function( error ) {
-		util.log( "Error (updateURLData 1): " + error.message )
+		util.log( "Error (updateURLData 1): " + error.message );
 	} );
 }
 
@@ -386,12 +387,12 @@ function checkURLStore() {
 // Outputs a common set of data after individual crawls and, if needed,
 // queues up the next request.
 function finishResult() {
-	util.log( "Status: " + wsu_web_crawler.scanned_urls.length + " scanned, " + wsu_web_crawler.stored_urls + " stored, " + c.queueSize + " queued");
+	util.log( "Status: " + wsu_web_crawler.scanned_urls.length + " scanned, " + wsu_web_crawler.stored_urls + " stored, " + c.queueSize + " queued" );
 
 	// If the queue is locked and the queue size is 0, reset the crawler.
 	if ( true === wsu_web_crawler.queue_lock && 0 < wsu_web_crawler.scan_urls.length && 0 === c.queueSize ) {
 		util.log( "Queue: Reset queue object" );
-		c = '';
+		c = "";
 		c = getCrawler();
 		wsu_web_crawler.queue_lock = false;
 	}
@@ -433,7 +434,7 @@ function handleCrawl( error, result, done ) {
  * @param {string} message
  */
 function handleCrawlLog( type, message ) {
-	if ( 'error' === type || 'critical' === type ) {
+	if ( "error" === type || "critical" === type ) {
 		util.log( "Error (Node Crawler): " + message );
 	}
 }

--- a/crawl.js
+++ b/crawl.js
@@ -15,8 +15,8 @@ var scanned_urls = [];
 // Tracks the list of URLs to be stored.
 var store_urls = process.env.START_URLS.split( "," );
 
-// Tracks the list of URLs stored.
-var stored_urls = [];
+// Tracks the number of URLs stored.
+var stored_urls = 0;
 
 var parse_href = new ParseHref( {
 
@@ -73,7 +73,7 @@ var storeURLs = function( response ) {
 			body: bulk_body
 		}, function( err, response ) {
 			if ( undefined !== typeof response ) {
-				stored_urls = stored_urls.concat( urls );
+				stored_urls = stored_urls + urls.length;
 				resolve();
 			} else {
 
@@ -175,7 +175,7 @@ var handleCrawlResult = function( res ) {
 				}
 
 				// Mark un-stored URLs to be stored.
-				if ( url && -1 >= stored_urls.indexOf( url ) && -1 >= store_urls.indexOf( url ) ) {
+				if ( url && -1 >= store_urls.indexOf( url ) ) {
 					store_urls.push( url );
 				}
 
@@ -247,9 +247,8 @@ var handleCrawlResult = function( res ) {
 						scan_urls.push( url );
 					}
 
-					// If a URL has not been stored and is not slated to be stored,
-					// mark it to be stored.
-					if ( -1 >= stored_urls.indexOf( url ) && -1 >= store_urls.indexOf( url ) ) {
+					// If a URL is not slated to be stored, mark it to be stored.
+					if ( -1 >= store_urls.indexOf( url ) ) {
 						store_urls.push( url );
 					}
 
@@ -320,7 +319,6 @@ var checkURLStore = function() {
 					var index = local_store_urls.indexOf( resp.hits.hits[ j ]._source.url );
 					if ( -1 < index ) {
 						local_store_urls.splice( index, 1 );
-						stored_urls.push( resp.hits.hits[ j ]._source.url );
 					}
 				}
 			}
@@ -350,7 +348,7 @@ var checkURLStore = function() {
 // Outputs a common set of data after individual crawls and, if needed,
 // queues up the next request.
 var finishResult = function() {
-	util.log( "Status: " + scanned_urls.length + " scanned, " + stored_urls.length + " stored" );
+	util.log( "Status: " + scanned_urls.length + " scanned, " + stored_urls + " stored" );
 
 	// Continue scanning until no URLs are left.
 	if ( 0 !== scan_urls.length  ) {


### PR DESCRIPTION
A lot in this:

* Used named functions instead of storing functions in variables.
* Use a global config object rather than individual global vars.
* Destory Elasticsearch object after every use.
* Limit node-crawler to 100 crawls before regenerating object.
* Use promises with ES rather than callbacks.
* Improve resove/reject handling and logging throughout.

This appears to improve the management of memory significantly.

There are still a large number of URLs that will be tracked and stored, so the total memory footprint of the app will grow over time. I'm hoping this does enough to give us a longer run time than several hours though.

Fixes #17. (For now) 😄 