### PR TITLE
[PR] Exclude various patterns for problematic sites

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,6 +29,7 @@ module.exports = function( grunt ) {
 			crawler_script: {
 				src: [ "./*.js", "./lib/*.js", "./tests/*.js" ],
 				options: {
+					esversion: 6,
 					bitwise: true,
 					curly: true,
 					eqeqeq: true,

--- a/lib/parse-href.js
+++ b/lib/parse-href.js
@@ -50,6 +50,13 @@ ParseHref.prototype.get_url = function get_url( href, source_uri ) {
 		}
 	}
 
+	// The research portal for WSU libraries also has a discoverable URL count over 200000,
+	// many of which are held in these compounded filters.
+	// @todo Extract this into a custom WSU rule.
+	if ( "research.wsulibs.wsu.edu" === url.hostname && url.path.indexOf( "/xmlui/discover?" ) === 0 ) {
+		return false;
+	}
+
 	// Rebuild /relative/path/
 	if ( null === url.protocol ) {
 		var build_url = parse_url.parse( source_uri );

--- a/lib/parse-href.js
+++ b/lib/parse-href.js
@@ -64,6 +64,21 @@ ParseHref.prototype.get_url = function get_url( href, source_uri ) {
 		return false;
 	}
 
+	if ( "wsm.wsu.edu" === url.hostname && "" !== url.query ) {
+		var parts = url.query.split( "&" );
+		var new_parts = [];
+		for ( var j = 0; j < parts.length; j++ ) {
+			if ( 0 === parts[ j ].search( /(action|redlink|printable|oldid)/ ) ) {
+				continue;
+			}
+
+			new_parts.push( parts[ j ] );
+		}
+
+		// Overwrite the previous HREF with only allowed query params.
+		url.href = url.href.replace( url.query, new_parts.join( "&" ) );
+	}
+
 	// Rebuild /relative/path/
 	if ( null === url.protocol ) {
 		var build_url = parse_url.parse( source_uri );

--- a/lib/parse-href.js
+++ b/lib/parse-href.js
@@ -57,6 +57,13 @@ ParseHref.prototype.get_url = function get_url( href, source_uri ) {
 		return false;
 	}
 
+	// Exclude a bunch of Mediawiki views that do not change and are not informative to
+	// WSU search or accessibility.
+	// @todo Extract this into a custom WSU rule.
+	if ( "wsm.wsu.edu" === url.hostname && url.path.indexOf( "/ourstory/index.php?title=Special:" ) === 0 ) {
+		return false;
+	}
+
 	// Rebuild /relative/path/
 	if ( null === url.protocol ) {
 		var build_url = parse_url.parse( source_uri );

--- a/lib/parse-href.js
+++ b/lib/parse-href.js
@@ -30,6 +30,26 @@ ParseHref.prototype.get_url = function get_url( href, source_uri ) {
 		}
 	}
 
+	// The WSU Plateau Portal has a discoverable URL count of over 2000000
+	// because of how the CMS surfaces the information. This reduces the load
+	// on that site. @todo Extract this into a custom WSU rule.
+	if ( "plateauportal.wsulibs.wsu.edu" === url.hostname ) {
+		var problematic_patterns = [
+			"/digital-heritage/category/",
+			"/digital-heritage/media-type/",
+			"/digital-heritage/keywords/",
+			"/digital-heritage/field_collection/",
+			"/digital-heritage/community/",
+			"/category/"
+		];
+
+		for ( var i = 0; i < problematic_patterns.length; i++ ) {
+			if ( url.path.indexOf( problematic_patterns[ i ] ) === 0 ) {
+				return false;
+			}
+		}
+	}
+
 	// Rebuild /relative/path/
 	if ( null === url.protocol ) {
 		var build_url = parse_url.parse( source_uri );

--- a/lib/parse-href.js
+++ b/lib/parse-href.js
@@ -43,7 +43,7 @@ ParseHref.prototype.get_url = function get_url( href, source_uri ) {
 			"/category/"
 		];
 
-		for ( var i = 0; i < problematic_patterns.length; i++ ) {
+		for ( let i = 0; i < problematic_patterns.length; i++ ) {
 			if ( url.path.indexOf( problematic_patterns[ i ] ) === 0 ) {
 				return false;
 			}
@@ -65,9 +65,9 @@ ParseHref.prototype.get_url = function get_url( href, source_uri ) {
 	}
 
 	if ( "wsm.wsu.edu" === url.hostname && "" !== url.query ) {
-		var parts = url.query.split( "&" );
-		var new_parts = [];
-		for ( var j = 0; j < parts.length; j++ ) {
+		let parts = url.query.split( "&" );
+		let new_parts = [];
+		for ( let j = 0; j < parts.length; j++ ) {
 			if ( 0 === parts[ j ].search( /(action|redlink|printable|oldid)/ ) ) {
 				continue;
 			}
@@ -80,9 +80,9 @@ ParseHref.prototype.get_url = function get_url( href, source_uri ) {
 	}
 
 	if ( "digitalexhibits.libraries.wsu.edu" === url.hostname && "" !== url.query ) {
-		var parts = url.query.split( "&" );
-		var new_parts = [];
-		for ( var j = 0; j < parts.length; j++ ) {
+		let parts = url.query.split( "&" );
+		let new_parts = [];
+		for ( let j = 0; j < parts.length; j++ ) {
 			if ( 0 === parts[ j ].search( /(sort_field|output)/ ) ) {
 				continue;
 			}

--- a/lib/parse-href.js
+++ b/lib/parse-href.js
@@ -79,6 +79,21 @@ ParseHref.prototype.get_url = function get_url( href, source_uri ) {
 		url.href = url.href.replace( url.query, new_parts.join( "&" ) );
 	}
 
+	if ( "digitalexhibits.libraries.wsu.edu" === url.hostname && "" !== url.query ) {
+		var parts = url.query.split( "&" );
+		var new_parts = [];
+		for ( var j = 0; j < parts.length; j++ ) {
+			if ( 0 === parts[ j ].search( /(sort_field|output)/ ) ) {
+				continue;
+			}
+
+			new_parts.push( parts[ j ] );
+		}
+
+		// Overwrite the previous HREF with only allowed query params.
+		url.href = url.href.replace( url.query, new_parts.join( "&" ) );
+	}
+
 	// Rebuild /relative/path/
 	if ( null === url.protocol ) {
 		var build_url = parse_url.parse( source_uri );

--- a/tests/test-parse-href-get-url.js
+++ b/tests/test-parse-href-get-url.js
@@ -127,3 +127,38 @@ test( "A relative URL with flagged file extension should report as false.", func
 	t.false( url );
 	t.end();
 } );
+
+test( "A /digital-heritage/category/ plateau portal path should report as false.", function( t ) {
+	var url = app.get_url( "https://plateauportal.wsulibs.wsu.edu/digital-heritage/category/", source_uri );
+
+	t.false( url );
+	t.end();
+} );
+
+test( "A /digital-heritage/media-type/ plateau portal path should report as false.", function( t ) {
+	var url = app.get_url( "https://plateauportal.wsulibs.wsu.edu/digital-heritage/media-type/", source_uri );
+
+	t.false( url );
+	t.end();
+} );
+
+test( "A /digital-heritage/keywords/ plateau portal path should report as false.", function( t ) {
+	var url = app.get_url( "https://plateauportal.wsulibs.wsu.edu/digital-heritage/keywords/", source_uri );
+
+	t.false( url );
+	t.end();
+} );
+
+test( "A /digital-heritage/field_collection/ plateau portal path should report as false.", function( t ) {
+	var url = app.get_url( "https://plateauportal.wsulibs.wsu.edu/digital-heritage/field_collection/", source_uri );
+
+	t.false( url );
+	t.end();
+} );
+
+test( "A /digital-heritage/community/ plateau portal path should report as false.", function( t ) {
+	var url = app.get_url( "https://plateauportal.wsulibs.wsu.edu/digital-heritage/community/", source_uri );
+
+	t.false( url );
+	t.end();
+} );

--- a/tests/test-parse-href-get-url.js
+++ b/tests/test-parse-href-get-url.js
@@ -218,3 +218,10 @@ test( "A WSM URL should be stripped of multiple blocked query parameters.", func
 	t.equal( url, "http://wsm.wsu.edu/ourstory/index.php?title=HelloWorld" );
 	t.end();
 } );
+
+test( "A digital exchibits URL should be stripped of multiple blocked query parameters.", function( t ) {
+	var url = app.get_url( "http://digitalexhibits.libraries.wsu.edu/items/browse?tags=France&sort_field=Dublin+Core%2CCreator&output=omeka-json", source_uri );
+
+	t.equal( url, "http://digitalexhibits.libraries.wsu.edu/items/browse?tags=France" );
+	t.end();
+} );

--- a/tests/test-parse-href-get-url.js
+++ b/tests/test-parse-href-get-url.js
@@ -176,3 +176,10 @@ test( "A /xmlui/discover path on research.wsulibs.wsu.edu with no additional dat
 	t.equal( url, "https://research.wsulibs.wsu.edu/xmlui/discover/" );
 	t.end();
 } );
+
+test( "A path starting with /ourstory/index.php?title=Special: on wsm.wsu.edu should report as false.", function( t ) {
+	var url = app.get_url( "http://wsm.wsu.edu/ourstory/index.php?title=Special:WhatLinksHere/Geology_Field_Trip", source_uri );
+
+	t.false( url );
+	t.end();
+} );

--- a/tests/test-parse-href-get-url.js
+++ b/tests/test-parse-href-get-url.js
@@ -162,3 +162,17 @@ test( "A /digital-heritage/community/ plateau portal path should report as false
 	t.false( url );
 	t.end();
 } );
+
+test( "A /xmlui/discover? research.wsulibs.wsu.edu path should report as false.", function( t ) {
+	var url = app.get_url( "https://research.wsulibs.wsu.edu/xmlui/discover?filtertype=morethings", source_uri );
+
+	t.false( url );
+	t.end();
+} );
+
+test( "A /xmlui/discover path on research.wsulibs.wsu.edu with no additional data should be allowed.", function( t ) {
+	var url = app.get_url( "https://research.wsulibs.wsu.edu/xmlui/discover/", source_uri );
+
+	t.equal( url, "https://research.wsulibs.wsu.edu/xmlui/discover/" );
+	t.end();
+} );

--- a/tests/test-parse-href-get-url.js
+++ b/tests/test-parse-href-get-url.js
@@ -183,3 +183,38 @@ test( "A path starting with /ourstory/index.php?title=Special: on wsm.wsu.edu sh
 	t.false( url );
 	t.end();
 } );
+
+test( "A WSM URL should be stripped of action query parameters.", function( t ) {
+	var url = app.get_url( "http://wsm.wsu.edu/ourstory/index.php?title=HelloWorld&action=nothing", source_uri );
+
+	t.equal( url, "http://wsm.wsu.edu/ourstory/index.php?title=HelloWorld" );
+	t.end();
+} );
+
+test( "A WSM URL should be stripped of redlink query parameters.", function( t ) {
+	var url = app.get_url( "http://wsm.wsu.edu/ourstory/index.php?title=HelloWorld&redlink=1", source_uri );
+
+	t.equal( url, "http://wsm.wsu.edu/ourstory/index.php?title=HelloWorld" );
+	t.end();
+} );
+
+test( "A WSM URL should be stripped of printable query parameters.", function( t ) {
+	var url = app.get_url( "http://wsm.wsu.edu/ourstory/index.php?title=HelloWorld&printable=yes", source_uri );
+
+	t.equal( url, "http://wsm.wsu.edu/ourstory/index.php?title=HelloWorld" );
+	t.end();
+} );
+
+test( "A WSM URL should be stripped of oldid query parameters.", function( t ) {
+	var url = app.get_url( "http://wsm.wsu.edu/ourstory/index.php?title=HelloWorld&oldid=1234", source_uri );
+
+	t.equal( url, "http://wsm.wsu.edu/ourstory/index.php?title=HelloWorld" );
+	t.end();
+} );
+
+test( "A WSM URL should be stripped of multiple blocked query parameters.", function( t ) {
+	var url = app.get_url( "http://wsm.wsu.edu/ourstory/index.php?title=HelloWorld&action=test&printable=yes&redlink=1&oldid=1234", source_uri );
+
+	t.equal( url, "http://wsm.wsu.edu/ourstory/index.php?title=HelloWorld" );
+	t.end();
+} );


### PR DESCRIPTION
Some sites generate a ton of URLs that are often the same content arranged slightly different. We can exclude these from being scanned so that active and more important URLs can be scanned more frequently.

Fixes #36 