### PR TITLE
[PR] Attempt to clear locked URLs on every queue

### DIFF
--- a/data-collector.js
+++ b/data-collector.js
@@ -188,7 +188,7 @@ function queueLockedURLs() {
 		index: process.env.ES_URL_INDEX,
 		type: "url",
 		body: {
-			size: 10,
+			size: 15,
 			query: {
 				match: {
 					"search_scan_priority": wsu_web_crawler.lock_key
@@ -196,7 +196,7 @@ function queueLockedURLs() {
 			}
 		}
 	} ).then( function( response ) {
-		if ( response.hits.total >= 25 ) {
+		if ( response.hits.total >= 14 ) {
 			wsu_web_crawler.locker_locked = true;
 		} else {
 			wsu_web_crawler.locker_locked = false;


### PR DESCRIPTION
Previously, the number of locked URLs exceeded the number that could
be queued at any time. This caused several URLs to never be crawled
even when in a high priority locked state.

Fixes #44